### PR TITLE
Trivial change to setup/index.php in the PHP backend

### DIFF
--- a/backend/php/src/setup/index.php
+++ b/backend/php/src/setup/index.php
@@ -164,7 +164,7 @@ if(count($_POST) > 0 && $_SESSION['diagnosticsSuccessful']==false)
 		if ($errors == 0)
 		{
 			AddTrace('File Structure....OK!');
-			if (!@mysql_connect ($GLOBALS['configuration']['host'].":".$GLOBALS['configuration']['port'], $GLOBALS['configuration']['user'], $GLOBALS['configuration']['pass']))
+			if (!mysql_connect ($GLOBALS['configuration']['host'].":".$GLOBALS['configuration']['port'], $GLOBALS['configuration']['user'], $GLOBALS['configuration']['pass']))
 			{
 				$errors++;
 				AddError('Cannot connect to the specified database server. Edit configuration.php');


### PR DESCRIPTION
I had some trouble tracking down a problem where the POG setup would silently fail, but I eventually discovered that it was because I didn't have the mysql module for PHP installed. I removed the @ sign from the call to @mysql_connect so that an error message will appear in the Apache logs in case anyone else has this problem.
