### PR TITLE
fix the cancel button for editing cards

### DIFF
--- a/frontend/beta/js/Clipperz/PM/DataModel/Record.js
+++ b/frontend/beta/js/Clipperz/PM/DataModel/Record.js
@@ -292,8 +292,14 @@ console.log("Record.processData", someValues);
 				this.setCurrentVersionKey(this.key());
 			}
 
-//			currentVersionParameters = someValues['currentVersion'];
-			currentVersionParameters = someValues['versions'][someValues['currentVersion']];
+//			community edition doesn't currently pass version
+//			information
+			if (someValues['versions'] == null) {
+				currentVersionParameters = someValues['currentVersion'];
+			} else {
+				currentVersionParameters = someValues['versions'][someValues['currentVersion']];
+			}
+
 console.log("Record.processData - this.currentVersionKey()", this.currentVersionKey());
 console.log("Record.processData - currentVersionParameters", currentVersionParameters);
 			currentVersionParameters['key'] = this.currentVersionKey();


### PR DESCRIPTION
The javascript was checking for the parameters assuming the backend
provided version information.  The community edition backend does not
supply any versioning information so the javascript checks both
locations
